### PR TITLE
Optimize mappingTable size

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,13 +21,12 @@ function findStatus(val, { useSTD3ASCIIRules }) {
     const max = Array.isArray(target[0]) ? target[0][1] : target[0];
 
     if (min <= val && max >= val) {
-      if (target[1] === STATUS_MAPPING.disallowed_STD3_valid || target[1] === STATUS_MAPPING.disallowed_STD3_mapped) {
-        if (useSTD3ASCIIRules) {
-          return [STATUS_MAPPING.disallowed, ...target.slice(2)];
-        } else if (target[1] === STATUS_MAPPING.disallowed_STD3_valid) {
-          return [STATUS_MAPPING.valid, ...target.slice(2)];
-        }
-
+      if (useSTD3ASCIIRules &&
+          (target[1] === STATUS_MAPPING.disallowed_STD3_valid || target[1] === STATUS_MAPPING.disallowed_STD3_mapped)) {
+        return [STATUS_MAPPING.disallowed, ...target.slice(2)];
+      } else if (target[1] === STATUS_MAPPING.disallowed_STD3_valid) {
+        return [STATUS_MAPPING.valid, ...target.slice(2)];
+      } else if (target[1] === STATUS_MAPPING.disallowed_STD3_mapped) {
         return [STATUS_MAPPING.mapped, ...target.slice(2)];
       }
 

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@
 const punycode = require("punycode");
 const regexes = require("./lib/regexes.js");
 const mappingTable = require("./lib/mappingTable.json");
+const { STATUS_MAPPING } = require("./statusMapping");
 
 function containsNonASCII(str) {
   return /[^\x00-\x7F]/.test(str);
@@ -16,13 +17,25 @@ function findStatus(val, { useSTD3ASCIIRules }) {
     const mid = Math.floor((start + end) / 2);
 
     const target = mappingTable[mid];
-    if (target[0][0] <= val && target[0][1] >= val) {
-      if (target[1].startsWith("disallowed_STD3_")) {
-        const newStatus = useSTD3ASCIIRules ? "disallowed" : target[1].slice(16);
+    const min = Array.isArray(target[0]) ? target[0][0] : target[0];
+    const max = Array.isArray(target[0]) ? target[0][1] : target[0];
+
+    if (min <= val && max >= val) {
+      if (target[1] === STATUS_MAPPING.disallowed_STD3_valid || target[1] === STATUS_MAPPING.disallowed_STD3_mapped) {
+        let newStatus = "";
+
+        if (useSTD3ASCIIRules) {
+          newStatus = STATUS_MAPPING.disallowed;
+        } else if (target[1] === STATUS_MAPPING.disallowed_STD3_valid) {
+          newStatus = STATUS_MAPPING.valid;
+        } else {
+          newStatus = STATUS_MAPPING.mapped;
+        }
+
         return [newStatus, ...target.slice(2)];
       }
       return target.slice(1);
-    } else if (target[0][0] > val) {
+    } else if (min > val) {
       end = mid - 1;
     } else {
       start = mid + 1;
@@ -40,23 +53,23 @@ function mapChars(domainName, { useSTD3ASCIIRules, processingOption }) {
     const [status, mapping] = findStatus(ch.codePointAt(0), { useSTD3ASCIIRules });
 
     switch (status) {
-      case "disallowed":
+      case STATUS_MAPPING.disallowed:
         hasError = true;
         processed += ch;
         break;
-      case "ignored":
+      case STATUS_MAPPING.ignored:
         break;
-      case "mapped":
+      case STATUS_MAPPING.mapped:
         processed += mapping;
         break;
-      case "deviation":
+      case STATUS_MAPPING.deviation:
         if (processingOption === "transitional") {
           processed += mapping;
         } else {
           processed += ch;
         }
         break;
-      case "valid":
+      case STATUS_MAPPING.valid:
         processed += ch;
         break;
     }
@@ -89,9 +102,9 @@ function validateLabel(label, { checkHyphens, checkBidi, checkJoiners, processin
 
   for (const ch of codePoints) {
     const [status] = findStatus(ch.codePointAt(0), { useSTD3ASCIIRules });
-    if ((processingOption === "transitional" && status !== "valid") ||
+    if ((processingOption === "transitional" && status !== STATUS_MAPPING.valid) ||
         (processingOption === "nontransitional" &&
-         status !== "valid" && status !== "deviation")) {
+         status !== STATUS_MAPPING.valid && status !== STATUS_MAPPING.deviation)) {
       return false;
     }
   }

--- a/index.js
+++ b/index.js
@@ -22,18 +22,15 @@ function findStatus(val, { useSTD3ASCIIRules }) {
 
     if (min <= val && max >= val) {
       if (target[1] === STATUS_MAPPING.disallowed_STD3_valid || target[1] === STATUS_MAPPING.disallowed_STD3_mapped) {
-        let newStatus = "";
-
         if (useSTD3ASCIIRules) {
-          newStatus = STATUS_MAPPING.disallowed;
+          return [STATUS_MAPPING.disallowed, ...target.slice(2)];
         } else if (target[1] === STATUS_MAPPING.disallowed_STD3_valid) {
-          newStatus = STATUS_MAPPING.valid;
-        } else {
-          newStatus = STATUS_MAPPING.mapped;
+          return [STATUS_MAPPING.valid, ...target.slice(2)];
         }
 
-        return [newStatus, ...target.slice(2)];
+        return [STATUS_MAPPING.mapped, ...target.slice(2)];
       }
+
       return target.slice(1);
     } else if (min > val) {
       end = mid - 1;

--- a/scripts/generateMappingTable.js
+++ b/scripts/generateMappingTable.js
@@ -4,6 +4,7 @@ const fs = require("fs");
 const path = require("path");
 const request = require("request");
 const { unicodeVersion } = require("../package.json");
+const { STATUS_MAPPING } = require("../statusMapping");
 
 request.get(`https://unicode.org/Public/idna/${unicodeVersion}/IdnaMappingTable.txt`, (err, res, body) => {
   if (err) {
@@ -25,7 +26,14 @@ request.get(`https://unicode.org/Public/idna/${unicodeVersion}/IdnaMappingTable.
     const range = cells[0].split("..");
     const start = parseInt(range[0], 16);
     const end = parseInt(range[1] || range[0], 16);
-    cells[0] = [start, end];
+    cells[0] = end === start ? start : [start, end];
+
+    cells[1] = STATUS_MAPPING[cells[1]];
+
+    if (cells[1] === STATUS_MAPPING.valid) {
+      lines.push(cells.slice(0, 2));
+      return;
+    }
 
     if (cells[2] !== undefined) {
       // Parse replacement to int[] array

--- a/statusMapping.js
+++ b/statusMapping.js
@@ -1,0 +1,11 @@
+"use strict";
+
+module.exports.STATUS_MAPPING = {
+  mapped: 1,
+  valid: 2,
+  disallowed: 3,
+  disallowed_STD3_valid: 4, // eslint-disable-line camelcase
+  disallowed_STD3_mapped: 5, // eslint-disable-line camelcase
+  deviation: 6,
+  ignored: 7
+};


### PR DESCRIPTION
Package size is currently [317kb](https://bundlephobia.com/result?p=tr46@2.0.0). 

The generated `mappingTable.json` alone is 253kb.

In this PR I optimize this file to be around 130kb (51% the original size):

- Use mappings to avoid using the same strings over and over
- Keep only the first bound of the range when mapping is for 1 charcode
- For `valid` charcodes, drop last 2 columns (not used)

I guess we could go a lot further. One way of drastically reducing the package size would be to build the mapping table during the `postInstall` phase and not package them.