### PR TITLE
Require punycode with trailing slash

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const punycode = require("punycode");
+const punycode = require("punycode/");
 const regexes = require("./lib/regexes.js");
 const mappingTable = require("./lib/mappingTable.json");
 const { STATUS_MAPPING } = require("./lib/statusMapping.js");


### PR DESCRIPTION
Quote from **Punycode.js** [README][1]:

> ⚠️ Note that userland modules don't hide core modules.
> For example, `require('punycode')` still imports the deprecated core module even if you executed `npm install punycode`.
> Use `require('punycode/')` to import userland modules rather than core modules.



[1]: https://github.com/mathiasbynens/punycode.js#installation