### PR TITLE
Further optimize mappingTable size

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ function findStatus(val, { useSTD3ASCIIRules }) {
 
     const target = mappingTable[mid];
     const min = Array.isArray(target[0]) ? target[0][0] : target[0];
-    const max = Array.isArray(target[0]) ? target[0][1] : target[0];
+    const max = Array.isArray(target[0]) ? (min + target[0][1]) : target[0];
 
     if (min <= val && max >= val) {
       if (useSTD3ASCIIRules &&

--- a/scripts/generateMappingTable.js
+++ b/scripts/generateMappingTable.js
@@ -29,7 +29,7 @@ async function main() {
     const range = cells[0].split("..");
     const start = parseInt(range[0], 16);
     const end = parseInt(range[1] || range[0], 16);
-    cells[0] = end === start ? start : [start, end];
+    cells[0] = end === start ? start : [start, end - start];
 
     cells[1] = STATUS_MAPPING[cells[1]];
 


### PR DESCRIPTION
This PR should reduce about 7KB(139KB ->132KB). The idea is simple: most ranges of rows in the table is small, which can be represented by `[start, difference]` in comparison with `[start, end]`.