### PR TITLE
fix: Update `punycode` import path

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const punycode = require("punycode");
+const punycode = require("punycode/");
 const regexes = require("./lib/regexes.js");
 const mappingTable = require("./lib/mappingTable.json");
 const { STATUS_MAPPING } = require("./lib/statusMapping.js");


### PR DESCRIPTION
With later Node versions, deprecation warnings began to appear about changing the import path to avoid using core modules, instead to use userland modules. This follows the advice for punycode's most recent version (v2.3.1). This should ideally be applied for a v3.0.1 tag so a number of active packages can remove this warning.