### PR TITLE
useSTD3ASCIIRules does not work in v5.1.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -132,7 +132,7 @@ function validateLabel(label, {
     // be a lowercase letter (a-z), a digit (0-9), or a hyphen-minus (U+002D). (Note: This excludes uppercase ASCII
     // A-Z which are mapped in UTS #46 and disallowed in IDNA2008.)"
     if (useSTD3ASCIIRules && codePoint <= 0x7F) {
-      if (!/^[a-z][0-9]-$/u.test(ch)) {
+      if (!/^([a-z]|[0-9]|-)$/u.test(ch)) {
         return false;
       }
     }

--- a/index.js
+++ b/index.js
@@ -132,7 +132,7 @@ function validateLabel(label, {
     // be a lowercase letter (a-z), a digit (0-9), or a hyphen-minus (U+002D). (Note: This excludes uppercase ASCII
     // A-Z which are mapped in UTS #46 and disallowed in IDNA2008.)"
     if (useSTD3ASCIIRules && codePoint <= 0x7F) {
-      if (!/^([a-z]|[0-9]|-)$/u.test(ch)) {
+      if (!/^(?:[a-z]|[0-9]|-)$/u.test(ch)) {
         return false;
       }
     }

--- a/test/std3ASCIIRules.js
+++ b/test/std3ASCIIRules.js
@@ -3,7 +3,6 @@ const { describe, test } = require("node:test");
 const assert = require("assert");
 const tr46 = require("../index.js");
 
-
 function testToASCIIWithSTD3ASCIIRules(testCase) {
   const result = tr46.toASCII(testCase.input, {
     checkBidi: false,
@@ -26,11 +25,13 @@ describe("ToASCII with useSTD3ASCIIRules = true123", () => {
 });
 
 describe("ToASCII with useSTD3ASCIIRules = true", () => {
+  const testCases = [];
+
+  // Add test cases for valid characters
   const alphabet = "abcdefghijklmnopqrstuvwxyz";
   const digits = "0123456789";
   const hyphen = "-";
   const allowedChars = alphabet + digits + hyphen;
-  const testCases = [];
   for (const char of allowedChars) {
     testCases.push({
       input: char,

--- a/test/std3ASCIIRules.js
+++ b/test/std3ASCIIRules.js
@@ -15,15 +15,6 @@ function testToASCIIWithSTD3ASCIIRules(testCase) {
   assert.strictEqual(result, testCase.output);
 }
 
-describe("ToASCII with useSTD3ASCIIRules = true123", () => {
-  test("sample test", () => {
-    testToASCIIWithSTD3ASCIIRules({
-      input: "a",
-      output: "a"
-    });
-  });
-});
-
 describe("ToASCII with useSTD3ASCIIRules = true", () => {
   const testCases = [];
 

--- a/test/std3ASCIIRules.js
+++ b/test/std3ASCIIRules.js
@@ -1,0 +1,107 @@
+"use strict";
+const { describe, test } = require("node:test");
+const assert = require("assert");
+const tr46 = require("../index.js");
+
+
+function testToASCIIWithSTD3ASCIIRules(testCase) {
+  const result = tr46.toASCII(testCase.input, {
+    checkBidi: false,
+    checkHyphens: false,
+    checkJoiners: false,
+    useSTD3ASCIIRules: true,
+    verifyDNSLength: false
+  });
+
+  assert.strictEqual(result, testCase.output);
+}
+
+describe("ToASCII with useSTD3ASCIIRules = true123", () => {
+  test("sample test", () => {
+    testToASCIIWithSTD3ASCIIRules({
+      input: "a",
+      output: "a"
+    });
+  });
+});
+
+describe("ToASCII with useSTD3ASCIIRules = true", () => {
+  const alphabet = "abcdefghijklmnopqrstuvwxyz";
+  const digits = "0123456789";
+  const hyphen = "-";
+  const allowedChars = alphabet + digits + hyphen;
+  const testCases = [];
+  for (const char of allowedChars) {
+    testCases.push({
+      input: char,
+      output: char,
+      comment: "STD3 range"
+    });
+  }
+
+  // Add not supported ascii characters
+  for (let i = 0; i < 128; i++) {
+    const char = String.fromCharCode(i);
+    if (allowedChars.includes(char)) {
+      continue;
+    }
+
+    // Upper-case letters are converted to lower case, so we we exclude them from a negative test case
+    if (allowedChars.includes(char.toLowerCase())) {
+      continue;
+    }
+
+    // Dot is exclude from negative test cases, since it is allowed in domain names
+    if (char === ".") {
+      continue;
+    }
+
+    testCases.push({
+      input: char,
+      output: null,
+      comment: "Outside of STD3 range"
+    });
+  }
+
+  // Add a unicode character, since it should be converted to punycode
+  testCases.push({
+    input: "é",
+    output: "xn--9ca",
+    comment: "Unicode"
+  });
+
+  // Additional test cases, with mixed valid and invalid characters
+  testCases.push({
+    input: "inv@alid",
+    output: null,
+    comment: "Invalid label"
+  });
+  testCases.push({
+    input: "valid",
+    output: "valid",
+    comment: "Valid label"
+  });
+  testCases.push({
+    input: "unicodé",
+    output: "xn--unicod-gva",
+    comment: "Valid uncode label"
+  });
+  testCases.push({
+    input: "uni!codé",
+    output: null,
+    comment: "Invalid uncode label"
+  });
+
+  for (const testCase of testCases) {
+    let description = testCase.input;
+
+    if (testCase.comment) {
+      description += ` (${testCase.comment})`;
+    }
+
+    test(description, () => {
+      testToASCIIWithSTD3ASCIIRules(testCase);
+    });
+  }
+});
+


### PR DESCRIPTION
- Fixed regex for STD3 characters validation
- Added unit tests for useSTD3ASCIIRules validation option