### PR TITLE
Compress mapping table a bit

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ function unpackMappingTable() {
 
   rangesTable = [];
   let current = 0;
-  const [rangesRaw, mappingRaw] = tablesRaw;
+  const [rangesRaw, statusesRaw, mappingRaw] = tablesRaw;
   while (rangesRaw.length > 0) {
     if (rangesRaw[0] < 0) {
       const repeats = -rangesRaw.shift(); // Treat as this many repeats of [1, 0]
@@ -36,11 +36,20 @@ function unpackMappingTable() {
   }
 
   mappingTable = [];
-  while (mappingRaw.length > 0) {
-    const status = mappingRaw[0];
-    const rowSize = status === STATUS_MAPPING.mapped || status === STATUS_MAPPING.deviation ? 2 : 1;
-    mappingTable.push(mappingRaw.splice(0, rowSize));
+  for (const status of statusesRaw) {
+    if (status < 0) {
+      // Threat this as many repeats of STATUS_MAPPING.mapped
+      for (let i = 0; i < -status; i++) {
+        mappingTable.push([STATUS_MAPPING.mapped, mappingRaw.shift()]);
+      }
+    } else if (status === STATUS_MAPPING.mapped || status === STATUS_MAPPING.deviation) {
+      mappingTable.push([status, mappingRaw.shift()]);
+    } else {
+      mappingTable.push([status]);
+    }
   }
+
+  statusesRaw.length = 0; // Destroy for mem
 }
 
 function findStatus(val) {

--- a/index.js
+++ b/index.js
@@ -19,7 +19,9 @@ function unpackMappingTable() {
   mappingTable = [];
   let current = 0;
   while (mappingTableRaw.length > 0) {
-    const row = mappingTableRaw.splice(0, 4); // Destroying the original, for mem
+    const status = mappingTableRaw[2];
+    const rowSize = status === STATUS_MAPPING.mapped || status === STATUS_MAPPING.deviation ? 4 : 3;
+    const row = mappingTableRaw.splice(0, rowSize); // Destroying the original, for mem
     row[0] = current += row[0];
     mappingTable.push(row);
   }
@@ -54,9 +56,9 @@ function mapChars(domainName, { transitionalProcessing }) {
   let processed = "";
 
   for (const ch of domainName) {
-    const [status, mapping] = findStatus(ch.codePointAt(0));
+    const row = findStatus(ch.codePointAt(0)); // [status, mapping]
 
-    switch (status) {
+    switch (row[0]) {
       case STATUS_MAPPING.disallowed:
         processed += ch;
         break;
@@ -66,12 +68,12 @@ function mapChars(domainName, { transitionalProcessing }) {
         if (transitionalProcessing && ch === "ẞ") {
           processed += "ss";
         } else {
-          processed += mapping;
+          processed += row[1];
         }
         break;
       case STATUS_MAPPING.deviation:
         if (transitionalProcessing) {
-          processed += mapping;
+          processed += row[1];
         } else {
           processed += ch;
         }

--- a/index.js
+++ b/index.js
@@ -13,6 +13,14 @@ function findStatus(val) {
   let start = 0;
   let end = mappingTable.length - 1;
 
+  // Unpack delta-coding in place once
+  if (mappingTable[2][0] < 10) {
+    let current = 0;
+    for (const row of mappingTable) {
+      row[0] = current += row[0];
+    }
+  }
+
   while (start <= end) {
     const mid = Math.floor((start + end) / 2);
 

--- a/index.js
+++ b/index.js
@@ -2,28 +2,37 @@
 
 const punycode = require("punycode/");
 const regexes = require("./lib/regexes.js");
-const mappingTableRaw = require("./lib/mappingTable.json");
+const tablesRaw = require("./lib/mappingTable.json");
 const { STATUS_MAPPING } = require("./lib/statusMapping.js");
 
 function containsNonASCII(str) {
   return /[^\x00-\x7F]/u.test(str);
 }
 
-let mappingTable;
+let rangesTable,
+  mappingTable;
 
 function unpackMappingTable() {
   if (mappingTable) {
     return;
   }
 
-  mappingTable = [];
+  // Destroying the originals, for mem
+
+  rangesTable = [];
   let current = 0;
-  while (mappingTableRaw.length > 0) {
-    const status = mappingTableRaw[2];
-    const rowSize = status === STATUS_MAPPING.mapped || status === STATUS_MAPPING.deviation ? 4 : 3;
-    const row = mappingTableRaw.splice(0, rowSize); // Destroying the original, for mem
+  const [rangesRaw, mappingRaw] = tablesRaw;
+  while (rangesRaw.length > 0) {
+    const row = rangesRaw.splice(0, 2);
     row[0] = current += row[0];
-    mappingTable.push(row);
+    rangesTable.push(row);
+  }
+
+  mappingTable = [];
+  while (mappingRaw.length > 0) {
+    const status = mappingRaw[0];
+    const rowSize = status === STATUS_MAPPING.mapped || status === STATUS_MAPPING.deviation ? 2 : 1;
+    mappingTable.push(mappingRaw.splice(0, rowSize));
   }
 }
 
@@ -31,17 +40,17 @@ function findStatus(val) {
   unpackMappingTable();
 
   let start = 0;
-  let end = mappingTable.length - 1;
+  let end = rangesTable.length - 1;
 
   while (start <= end) {
     const mid = Math.floor((start + end) / 2);
 
-    const target = mappingTable[mid];
+    const target = rangesTable[mid];
     const min = target[0];
     const max = min + target[1];
 
     if (min <= val && max >= val) {
-      return target.slice(2);
+      return mappingTable[mid];
     } else if (min > val) {
       end = mid - 1;
     } else {

--- a/index.js
+++ b/index.js
@@ -17,11 +17,11 @@ function findStatus(val) {
     const mid = Math.floor((start + end) / 2);
 
     const target = mappingTable[mid];
-    const min = Array.isArray(target[0]) ? target[0][0] : target[0];
-    const max = Array.isArray(target[0]) ? target[0][1] : target[0];
+    const min = target[0];
+    const max = min + target[1];
 
     if (min <= val && max >= val) {
-      return target.slice(1);
+      return target.slice(2);
     } else if (min > val) {
       end = mid - 1;
     } else {

--- a/index.js
+++ b/index.js
@@ -2,24 +2,34 @@
 
 const punycode = require("punycode/");
 const regexes = require("./lib/regexes.js");
-const mappingTable = require("./lib/mappingTable.json");
+const mappingTableRaw = require("./lib/mappingTable.json");
 const { STATUS_MAPPING } = require("./lib/statusMapping.js");
 
 function containsNonASCII(str) {
   return /[^\x00-\x7F]/u.test(str);
 }
 
+let mappingTable;
+
+function unpackMappingTable() {
+  if (mappingTable) {
+    return;
+  }
+
+  mappingTable = [];
+  let current = 0;
+  while (mappingTableRaw.length > 0) {
+    const row = mappingTableRaw.splice(0, 4); // Destroying the original, for mem
+    row[0] = current += row[0];
+    mappingTable.push(row);
+  }
+}
+
 function findStatus(val) {
+  unpackMappingTable();
+
   let start = 0;
   let end = mappingTable.length - 1;
-
-  // Unpack delta-coding in place once
-  if (mappingTable[2][0] < 10) {
-    let current = 0;
-    for (const row of mappingTable) {
-      row[0] = current += row[0];
-    }
-  }
 
   while (start <= end) {
     const mid = Math.floor((start + end) / 2);

--- a/index.js
+++ b/index.js
@@ -23,9 +23,16 @@ function unpackMappingTable() {
   let current = 0;
   const [rangesRaw, mappingRaw] = tablesRaw;
   while (rangesRaw.length > 0) {
-    const row = rangesRaw.splice(0, 2);
-    row[0] = current += row[0];
-    rangesTable.push(row);
+    if (rangesRaw[0] < 0) {
+      const repeats = -rangesRaw.shift(); // Treat as this many repeats of [1, 0]
+      for (let i = 0; i < repeats; i++) {
+        rangesTable.push([++current, 0]);
+      }
+    } else {
+      const row = rangesRaw.splice(0, 2);
+      row[0] = current += row[0];
+      rangesTable.push(row);
+    }
   }
 
   mappingTable = [];

--- a/scripts/generateMappingTable.js
+++ b/scripts/generateMappingTable.js
@@ -60,5 +60,12 @@ async function main() {
   // We could drop valid chars, but those are only ~1000 ranges and
   // binary search is way to quick to even notice that
 
+  // Delta-code starts
+  let last = 0;
+  for (const line of lines) {
+    line[0] -= last;
+    last += line[0];
+  }
+
   fs.writeFileSync(path.resolve(__dirname, "../lib/mappingTable.json"), JSON.stringify(lines));
 }

--- a/scripts/generateMappingTable.js
+++ b/scripts/generateMappingTable.js
@@ -36,7 +36,8 @@ async function main() {
     cells[1] = STATUS_MAPPING[cells[1]];
 
     if (cells[1] === STATUS_MAPPING.valid) {
-      lines.push(cells.slice(0, 2).flat());
+      cells[2] = 0;
+      lines.push(cells.slice(0, 3).flat());
       return;
     }
 
@@ -52,6 +53,8 @@ async function main() {
       });
 
       cells[2] = String.fromCodePoint(...replacement);
+    } else {
+      cells[2] = 0;
     }
 
     lines.push(cells.flat());
@@ -67,5 +70,5 @@ async function main() {
     last += line[0];
   }
 
-  fs.writeFileSync(path.resolve(__dirname, "../lib/mappingTable.json"), JSON.stringify(lines));
+  fs.writeFileSync(path.resolve(__dirname, "../lib/mappingTable.json"), JSON.stringify(lines.flat()));
 }

--- a/scripts/generateMappingTable.js
+++ b/scripts/generateMappingTable.js
@@ -32,12 +32,11 @@ async function main() {
     const range = cells[0].split("..");
     const start = parseInt(range[0], 16);
     const end = parseInt(range[1] || range[0], 16);
-    cells[0] = end === start ? start : [start, end];
-
+    cells[0] = [start, end - start];
     cells[1] = STATUS_MAPPING[cells[1]];
 
     if (cells[1] === STATUS_MAPPING.valid) {
-      lines.push(cells.slice(0, 2));
+      lines.push(cells.slice(0, 2).flat());
       return;
     }
 
@@ -55,7 +54,7 @@ async function main() {
       cells[2] = String.fromCodePoint(...replacement);
     }
 
-    lines.push(cells);
+    lines.push(cells.flat());
   });
 
   // We could drop valid chars, but those are only ~1000 ranges and

--- a/scripts/generateMappingTable.js
+++ b/scripts/generateMappingTable.js
@@ -17,6 +17,7 @@ async function main() {
   }
   const body = await response.text();
 
+  const ranges = [];
   const lines = [];
 
   body.split("\n").forEach(l => {
@@ -33,16 +34,17 @@ async function main() {
     const start = parseInt(range[0], 16);
     const end = parseInt(range[1] || range[0], 16);
     cells[0] = [start, end - start];
-    cells[1] = STATUS_MAPPING[cells[1]];
+    ranges.push(cells.shift());
 
-    if (cells[1] !== STATUS_MAPPING.mapped && cells[1] !== STATUS_MAPPING.deviation) {
-      lines.push(cells.slice(0, 2).flat());
+    cells[0] = STATUS_MAPPING[cells[0]];
+    if (cells[0] !== STATUS_MAPPING.mapped && cells[0] !== STATUS_MAPPING.deviation) {
+      lines.push(cells[0]);
       return;
     }
 
-    if (cells[2] !== undefined) {
+    if (cells[1] !== undefined) {
       // Parse replacement to int[] array
-      let replacement = cells[2].split(" ");
+      let replacement = cells[1].split(" ");
       if (replacement[0] === "") { // Empty array
         replacement = [];
       }
@@ -51,7 +53,7 @@ async function main() {
         return parseInt(r, 16);
       });
 
-      cells[2] = String.fromCodePoint(...replacement);
+      cells[1] = String.fromCodePoint(...replacement);
     } else {
       throw new Error("Unexpected");
     }
@@ -64,10 +66,10 @@ async function main() {
 
   // Delta-code starts
   let last = 0;
-  for (const line of lines) {
-    line[0] -= last;
-    last += line[0];
+  for (const range of ranges) {
+    range[0] -= last;
+    last += range[0];
   }
 
-  fs.writeFileSync(path.resolve(__dirname, "../lib/mappingTable.json"), JSON.stringify(lines.flat()));
+  fs.writeFileSync(path.resolve(__dirname, "../lib/mappingTable.json"), JSON.stringify([ranges.flat(), lines.flat()]));
 }

--- a/scripts/generateMappingTable.js
+++ b/scripts/generateMappingTable.js
@@ -71,5 +71,27 @@ async function main() {
     last += range[0];
   }
 
-  fs.writeFileSync(path.resolve(__dirname, "../lib/mappingTable.json"), JSON.stringify([ranges.flat(), lines.flat()]));
+  // Condense repeats of N consecutive [1, 0] in ranges to -N
+  const rangesCondensed = [];
+  let repeats = 0;
+  for (const row of ranges) {
+    if (row[0] === 1 && row[1] === 0) {
+      repeats++;
+      continue;
+    }
+
+    if (repeats > 0) {
+      rangesCondensed.push(-repeats);
+      repeats = 0;
+    }
+
+    rangesCondensed.push(row);
+  }
+
+  if (repeats > 0) {
+    rangesCondensed.push(-repeats);
+  }
+
+  const tablesRaw = [rangesCondensed.flat(), lines.flat()];
+  fs.writeFileSync(path.resolve(__dirname, "../lib/mappingTable.json"), JSON.stringify(tablesRaw));
 }

--- a/scripts/generateMappingTable.js
+++ b/scripts/generateMappingTable.js
@@ -35,9 +35,8 @@ async function main() {
     cells[0] = [start, end - start];
     cells[1] = STATUS_MAPPING[cells[1]];
 
-    if (cells[1] === STATUS_MAPPING.valid) {
-      cells[2] = 0;
-      lines.push(cells.slice(0, 3).flat());
+    if (cells[1] !== STATUS_MAPPING.mapped && cells[1] !== STATUS_MAPPING.deviation) {
+      lines.push(cells.slice(0, 2).flat());
       return;
     }
 
@@ -54,7 +53,7 @@ async function main() {
 
       cells[2] = String.fromCodePoint(...replacement);
     } else {
-      cells[2] = 0;
+      throw new Error("Unexpected");
     }
 
     lines.push(cells.flat());

--- a/scripts/generateMappingTable.js
+++ b/scripts/generateMappingTable.js
@@ -18,7 +18,8 @@ async function main() {
   const body = await response.text();
 
   const ranges = [];
-  const lines = [];
+  const statuses = [];
+  const mappings = [];
 
   body.split("\n").forEach(l => {
     l = l.split("#")[0]; // Remove comments
@@ -36,15 +37,16 @@ async function main() {
     cells[0] = [start, end - start];
     ranges.push(cells.shift());
 
-    cells[0] = STATUS_MAPPING[cells[0]];
-    if (cells[0] !== STATUS_MAPPING.mapped && cells[0] !== STATUS_MAPPING.deviation) {
-      lines.push(cells[0]);
+    const status = STATUS_MAPPING[cells.shift()];
+    statuses.push(status);
+
+    if (status !== STATUS_MAPPING.mapped && status !== STATUS_MAPPING.deviation) {
       return;
     }
 
-    if (cells[1] !== undefined) {
+    if (cells[0] !== undefined) {
       // Parse replacement to int[] array
-      let replacement = cells[1].split(" ");
+      let replacement = cells[0].split(" ");
       if (replacement[0] === "") { // Empty array
         replacement = [];
       }
@@ -53,12 +55,10 @@ async function main() {
         return parseInt(r, 16);
       });
 
-      cells[1] = String.fromCodePoint(...replacement);
+      mappings.push(String.fromCodePoint(...replacement));
     } else {
       throw new Error("Unexpected");
     }
-
-    lines.push(cells.flat());
   });
 
   // We could drop valid chars, but those are only ~1000 ranges and
@@ -71,7 +71,7 @@ async function main() {
     last += range[0];
   }
 
-  // Condense repeats of N consecutive [1, 0] in ranges to -N
+  // Condense repeats of N consecutive [1, 0] in ranges to -N, flatten the rest
   const rangesCondensed = [];
   let repeats = 0;
   for (const row of ranges) {
@@ -85,13 +85,35 @@ async function main() {
       repeats = 0;
     }
 
-    rangesCondensed.push(row);
+    rangesCondensed.push(...row);
   }
 
   if (repeats > 0) {
     rangesCondensed.push(-repeats);
+    repeats = 0;
   }
 
-  const tablesRaw = [rangesCondensed.flat(), lines.flat()];
+  // Condense repeats of N consecutive STATUS_MAPPING.mapped to -N
+  const statusesCondensed = [];
+  for (const status of statuses) {
+    if (status === STATUS_MAPPING.mapped) {
+      repeats++;
+      continue;
+    }
+
+    if (repeats > 0) {
+      statusesCondensed.push(repeats === 1 ? STATUS_MAPPING.mapped : -repeats);
+      repeats = 0;
+    }
+
+    statusesCondensed.push(status);
+  }
+
+  if (repeats > 0) {
+    statusesCondensed.push(repeats === 1 ? STATUS_MAPPING.mapped : -repeats);
+    repeats = 0;
+  }
+
+  const tablesRaw = [rangesCondensed, statusesCondensed, mappings];
   fs.writeFileSync(path.resolve(__dirname, "../lib/mappingTable.json"), JSON.stringify(tablesRaw));
 }


### PR DESCRIPTION
This is an `~1.85x` gzipped size reduction and an `~1.27x` perf improvement.

Package size, before: 236 KiB minified, 60 KiB gzipped
Package size, after: 152 KiB minified, 32.5 KiB gzipped

Bench: `230,482` -> `292,052` ops/sec

Changes done:
1. Store ranges, statuses and mappings separately. This is good for gzip _and_ for perf as it avoids `.slice()` during mapping
2. Avoid destructuring past array length (`mapping` is non-existent for some `status` values)
3. Delta-code everything and unpack on first use
4. Flatten the array for storage and unpack on first use
5. Condense repeats (almost does not affect gzip as it can do that itself, but affects on-disk size)

Further optimization is possible but I decided to stop somewhere for now